### PR TITLE
Team authority

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -23,7 +23,6 @@ class AgendasController < ApplicationController
   end
 
   def destroy
-    # binding.pry
     if current_user.id == @agenda.user_id || @working_team.owner_id
       @agenda.destroy
       DestroyAgendaMailer.destroy_agenda_mail(@agenda).deliver

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -50,6 +50,8 @@ class TeamsController < ApplicationController
   def change_owner
     @working_team.owner_id = params[:id]
     @working_team.save
+    new_owner = @working_team.owner
+    NominatedToOwnerMailer.nominated_to_owner_mail(new_owner).deliver
   end
 
   private

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -52,6 +52,7 @@ class TeamsController < ApplicationController
     @working_team.save
     new_owner = @working_team.owner
     NominatedToOwnerMailer.nominated_to_owner_mail(new_owner).deliver
+    redirect_back(fallback_location: team_path(@working_team))
   end
 
   private

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -48,11 +48,15 @@ class TeamsController < ApplicationController
   end
 
   def change_owner
-    @working_team.owner_id = params[:id]
-    @working_team.save
-    new_owner = @working_team.owner
-    NominatedToOwnerMailer.nominated_to_owner_mail(new_owner).deliver
-    redirect_back(fallback_location: team_path(@working_team))
+    if current_user == @working_team.owner
+      @working_team.owner_id = params[:id]
+      @working_team.save
+      new_owner = @working_team.owner
+      NominatedToOwnerMailer.nominated_to_owner_mail(new_owner).deliver
+      redirect_back(fallback_location: team_path(@working_team))
+    else
+      I18n.t('views.messages.no_authority_without_owner')
+    end
   end
 
   private

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -47,6 +47,11 @@ class TeamsController < ApplicationController
     @team = current_user.keep_team_id ? Team.find(current_user.keep_team_id) : current_user.teams.first
   end
 
+  def change_owner
+    @working_team.owner_id = params[:id]
+    @working_team.save
+  end
+
   private
 
   def set_team

--- a/app/mailers/nominated_to_owner_mailer.rb
+++ b/app/mailers/nominated_to_owner_mailer.rb
@@ -1,0 +1,5 @@
+class NominatedToOwnerMailer < ApplicationMailer
+  def nominated_to_owner_mail(new_owner)
+    mail to: new_owner.email, subject: I18n.t('views.messages.nominated_to_owner')
+  end
+end

--- a/app/views/nominated_to_owner_mailer/nominated_to_owner_mail.html.erb
+++ b/app/views/nominated_to_owner_mailer/nominated_to_owner_mail.html.erb
@@ -1,0 +1,1 @@
+<h1><%= I18n.t('views.messages.nominated_to_owner') %></h1>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -42,6 +42,7 @@
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
                       <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <td><%= link_to I18n.t('views.messages.move_authority'), class: 'btn btn-sm btn-danger' %></td>
                     </tr>
                   <% end %>
                 </tbody>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -42,7 +42,9 @@
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
                       <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
-                      <td><%= link_to I18n.t('views.messages.move_authority'), class: 'btn btn-sm btn-danger' %></td>
+                      <% if @working_team.owner_id == current_user.id %>
+                        <td><%= link_to I18n.t('views.messages.move_authority'), class: 'btn btn-sm btn-danger' %></td>
+                      <% end%>
                     </tr>
                   <% end %>
                 </tbody>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -42,8 +42,8 @@
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
                       <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
-                      <% if @working_team.owner_id == current_user.id %>
-                        <td><%= link_to I18n.t('views.messages.move_authority'), class: 'btn btn-sm btn-danger' %></td>
+                      <% if @team.owner_id == current_user.id %>
+                        <td><%= link_to I18n.t('views.messages.move_authority'), change_owner_team_path(assign.user_id), method: :patch, class: 'btn btn-sm btn-danger' %></td>
                       <% end%>
                     </tr>
                   <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -253,6 +253,7 @@ ja:
       posted_articles: '投稿した記事一覧'
       delete_agenda: 'アジェンダが削除されました。'
       move_authority: '権限移動'
+      nominated_to_owner: 'チームリーダーに指名されました。'
     button:
       submit: '投稿'
       edit: '編集'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -252,6 +252,7 @@ ja:
       team_you_belong_to: '所属しているチーム'
       posted_articles: '投稿した記事一覧'
       delete_agenda: 'アジェンダが削除されました。'
+      move_authority: '権限移動'
     button:
       submit: '投稿'
       edit: '編集'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -254,6 +254,7 @@ ja:
       delete_agenda: 'アジェンダが削除されました。'
       move_authority: '権限移動'
       nominated_to_owner: 'チームリーダーに指名されました。'
+      no_authority_without_owner: 'チームリーダー以外には権限がありません。'
     button:
       submit: '投稿'
       edit: '編集'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
   resource :user
   
   resources :teams do
+    member do
+      patch :change_owner
+    end
     resources :assigns, only: %w(create destroy)
     resources :agendas, shallow: true do
       resources :articles do

--- a/spec/mailers/nominated_to_owner_mailer_spec.rb
+++ b/spec/mailers/nominated_to_owner_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe NominatedToOwnerMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/nominated_to_owner_mailer_preview.rb
+++ b/spec/mailers/previews/nominated_to_owner_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/nominated_to_owner_mailer
+class NominatedToOwnerMailerPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
- [ ] そのTeamのリーダー（オーナー）が、Teamのshowページを開くと、各チームメンバーの「削除」ボタンの右隣に「権限移動」のボタンが出現する

- [ ] そのボタンを押すと、そのTeamのオーナーが選択したUserに変更される

- [ ] アクションはTeamコントローラに任意のものを追加する

- [ ] Teamのオーナーが変更されたら、新しくオーナーになったユーザーに通知メールが飛ぶ

- [ ] 情報処理が完了した後はそのTeamのshowに飛ぶ（つまり同じ場所にredirectする）

- [ ] その他、アプリケーションの挙動に不審な点やエラーがないこと